### PR TITLE
Require autoload verwijderd

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -7,8 +7,6 @@ use Xolphin\Endpoint\Certificate;
 use Xolphin\Endpoint\Request;
 use Xolphin\Endpoint\Support;
 
-require 'vendor/autoload.php';
-
 class Client {
     const BASE_URI = 'https://api.xolphin.com/v%d/';
     const VERSION = 1;


### PR DESCRIPTION
`require 'vendor/autoload.php';` moet niet in de library zelf aangeroepen worden. Bovendien werkt deze require helemaal niet, want `vendor` staat helemaal niet in de `src` map.
