### PR TITLE
Convert RequestException into XolphinRequestException

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Exception\RequestException;
 use Xolphin\Endpoint\Certificate;
 use Xolphin\Endpoint\Request;
 use Xolphin\Endpoint\Support;
+use Xolphin\Exception\XolphinRequestException;
 
 class Client {
     const BASE_URI = 'https://api.xolphin.com/v%d/';
@@ -53,16 +54,7 @@ class Client {
             $result = $this->guzzle->get($method, ['query' => $data]);
             return json_decode($result->getBody());
         } catch (RequestException $e) {
-            $data = json_decode($e->getResponse()->getBody());
-            if($data == NULL) {
-                throw new \Exception($e->getResponse()->getBody());
-            } else {
-                if(isset($data->message) || isset($data->errors)) {
-                    throw new \Exception(json_encode($data), $e->getCode());
-                } else {
-                    throw new \Exception($e->getMessage(), $e->getCode());
-                }
-            }
+            throw XolphinRequestException::createFromRequestException($e);
         }
     }
 
@@ -93,12 +85,7 @@ class Client {
             $result = $this->guzzle->post($method, ['multipart' => $mp]);
             return json_decode($result->getBody());
         } catch (RequestException $e) {
-            $data = json_decode($e->getResponse()->getBody());
-            if($data == NULL) {
-                throw new \Exception($e->getResponse()->getBody());
-            } else {
-                throw new \Exception(json_encode($data), $e->getCode());
-            }
+            throw XolphinRequestException::createFromRequestException($e);
         }
     }
 
@@ -113,12 +100,7 @@ class Client {
             $result = $this->guzzle->get($method, ['query' => $data]);
             return $result->getBody();
         } catch (RequestException $e) {
-            try {
-                $data = json_decode($e->getResponse()->getBody());
-                throw new \Exception($data->message);
-            } catch (\Exception $ex) {
-                throw new \Exception($e->getResponse()->getBody());
-            }
+            throw XolphinRequestException::createFromRequestException($e);
         }
     }
 

--- a/src/Exception/XolphinRequestException.php
+++ b/src/Exception/XolphinRequestException.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Xolphin\Exception;
+
+use GuzzleHttp\Exception\RequestException;
+
+class XolphinRequestException extends \Exception
+{
+    /** @var mixed */
+    private $errors;
+
+    /**
+     * @return mixed
+     */
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @param RequestException $requestException
+     *
+     * @return XolphinRequestException
+     */
+    public static function createFromRequestException(RequestException $requestException)
+    {
+        $data = json_decode($requestException->getResponse()->getBody());
+
+        if ($data == null) {
+            return new self($requestException->getResponse()->getBody(), null, $requestException);
+        }
+
+        if (!isset($data->message)) {
+            return new self($requestException->getMessage(), $requestException->getCode());
+        }
+
+        $customException         = new self($data->message, $requestException->getCode(), $requestException);
+        $customException->errors = (isset($data->errors)) ? $data->errors : null;
+
+        return $customException;
+    }
+}


### PR DESCRIPTION
I'm currently working on implementing xolphin for a customer but when i try to `renew` a certificate which requirers extra fields like the `address` field the back-end gives a 400 error. That is ok but because the `RequestException` is handled here i'm not able to get to the internals and get the `errors` array. 

I implemented a custom `XolphinRequestException` which converts the `RequestException` into a  `XolphinRequestException` that has this field when it is available. 

The formatting of the results is also moved as suggested in this article. 
* http://rosstuck.com/formatting-exception-messages/

When we fix #4 i can write some tests for it.