### PR TITLE
Notes added to request object

### DIFF
--- a/src/Responses/Note.php
+++ b/src/Responses/Note.php
@@ -4,6 +4,9 @@ namespace Xolphin\Responses;
 
 class Note extends \Xolphin\Responses\Base{
 
+    /** @var integer */
+    public $id;
+
     /** @var string */
     public $contact;
 
@@ -30,6 +33,7 @@ class Note extends \Xolphin\Responses\Base{
 
         parent::__construct($data);
 
+        if(isset($data->id)) $this->id = $data->id;
         if(isset($data->contact)) $this->contact = $data->contact;
         if(isset($data->staff)) $this->staff = $data->staff;
         if(isset($data->date)) $this->date = $data->date;

--- a/src/Responses/Request.php
+++ b/src/Responses/Request.php
@@ -70,6 +70,11 @@ class Request extends Base {
     public $brandValidation = false;
 
     /**
+     * @var Note[]
+     */
+    public $notes=[];
+
+    /**
      * Request constructor.
      * @param object $data
      */
@@ -103,10 +108,14 @@ class Request extends Base {
                     $this->validations[$k] = new RequestValidation($data->validations->$k);
                 }
             }
-
             if(isset($data->_embedded->product)) {
                 $this->product = new Product($data->_embedded->product);
-            };
+            }
+            if (isset($data->_embedded->notes) && is_array($data->_embedded->notes)) {
+                foreach ($data->_embedded->notes as $note) {
+                    $this->notes[] = new Note($note);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
- Add notes to the Request response. Since they are present. Might as well let them be usable. Saves a request
- A note has an ID. So that ID is now present in the response object.
