### PR TITLE
Feature/renew and request consistency

### DIFF
--- a/src/Requests/Renew.php
+++ b/src/Requests/Renew.php
@@ -5,7 +5,7 @@ namespace Xolphin\Requests;
 use Xolphin\Responses\Product;
 
 class Renew {
-    /** @var Product */
+    /** @var int|Product */
     private $product;
 
     /** @var int */
@@ -75,7 +75,12 @@ class Renew {
 
     public function getArray() {
         $result = [];
-        $result['product'] = $this->product->id;
+        if (is_object($this->product)) {
+            $result['product'] = $this->product->id;
+        } else {
+            $result['product'] = $this->product;
+        }
+
         $result['years'] = $this->years;
         $result['csr'] = $this->csr;
         $result['dcvType'] = $this->dcvType;

--- a/src/Requests/Renew.php
+++ b/src/Requests/Renew.php
@@ -61,7 +61,7 @@ class Renew {
 
     /**
      * Renew constructor.
-     * @param Product $product
+     * @param int|Product $product
      * @param int $years
      * @param string $csr
      * @param string $dcvType

--- a/src/Requests/Request.php
+++ b/src/Requests/Request.php
@@ -6,7 +6,7 @@ use Xolphin\Responses\Product;
 
 class Request
 {
-    /** @var int */
+    /** @var int|Product */
     private $product;
 
     /** @var int */
@@ -65,7 +65,7 @@ class Request
 
     /**
      * Request constructor.
-     * @param int $product
+     * @param int|Product $product
      * @param int $years
      * @param string $csr
      * @param string $dcvType
@@ -81,8 +81,15 @@ class Request
     public function getArray()
     {
         $result = [];
+        if(is_object($this->product))
+        {
+            $result['product'] = $this->product->id;
+        }
+        else
+        {
+            $result['product'] = $this->product;
+        }
 
-        $result['product'] = $this->product;
         $result['years'] = $this->years;
         $result['csr'] = $this->csr;
         $result['dcvType'] = $this->dcvType;


### PR DESCRIPTION
Request assumes the $product value to be an integer. And the Renew class assumes it to be a Product. But this is not enforced in either with a type declaration or a check and this is inconsistent between the two.

Renew:
https://github.com/xolphin/xolphin-api-php/blob/709c24efa6f33342799f1e3b1abd86d722e5044c/src/Requests/Renew.php#L78

Request:
https://github.com/xolphin/xolphin-api-php/blob/709c24efa6f33342799f1e3b1abd86d722e5044c/src/Requests/Request.php#L85

Suggested solution:
Instead of breaking the client for anyone currently using it in this manner(We just cast it to an object and that works for now). Allowing people to input an integer on the Renew&Request class constructor and checking in the getArray method by checking if it is an object or not and then either just placing the $this->product or $this->product->id into the array

This is what this pull request does. 

An alternative could be to enforce the Product on both renew and request class constructors with a type declaration. This would be problematic for anyone already using this client.