### PR TITLE
Make contact and staff properties of Note class nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the wrapper will be documented in this file.
 
+## [Unreleased]
+### Updated
+- The `contact` and `staff` properties of the `Note` response are now nullable.
+### Added
+- Added a test class for the Note response to assert nullable properties.
+
 ## [3.0.0]
 ### Updated
 - Dropped support for all versions below PHP 7.4

--- a/src/Responses/Note.php
+++ b/src/Responses/Note.php
@@ -38,7 +38,7 @@ class Note extends Base
      * @param object $data
      * @throws Exception
      */
-    function __construct($data)
+    public function __construct($data)
     {
         parent::__construct($data);
 

--- a/src/Responses/Note.php
+++ b/src/Responses/Note.php
@@ -12,11 +12,11 @@ class Note extends Base
     /** @var int */
     public int $id;
 
-    /** @var string */
-    public string $contact;
+    /** @var string|null */
+    public ?string $contact = null;
 
-    /** @var string */
-    public string $staff;
+    /** @var string|null */
+    public ?string $staff = null;
 
     /** @var string */
     public string $date;

--- a/tests/Responses/NoteTest.php
+++ b/tests/Responses/NoteTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Responses;
+
+use Tests\TestCase;
+use Xolphin\Responses\Note;
+
+class NoteTest extends TestCase
+{
+    public function testConstructWithStaffAndContact()
+    {
+        $noteData = [
+            'message' => 'Test message',
+            'staff' => 'Staff name',
+            'contact' => 'Contact name',
+        ];
+
+        $note = new Note((object) $noteData);
+
+        $this->assertEquals('Test message', $note->messageBody);
+        $this->assertEquals('Staff name', $note->staff);
+        $this->assertEquals('Contact name', $note->contact);
+    }
+
+
+    public function testConstructWithoutStaffAndContact()
+    {
+        $noteData = [
+            'message' => 'Test message',
+        ];
+
+        $note = new Note((object) $noteData);
+
+        $this->assertEquals('Test message', $note->messageBody);
+        $this->assertNull($note->staff);
+        $this->assertNull($note->contact);
+    }
+}


### PR DESCRIPTION
## Problem
When getting notes from the Xolphin API, the response can contain a null value for contact and/or staff.

API response (obfuscated):
```
{
    "staff": "Employee name",
    "time": "16:15",
    "id": "123",
    "contact": null,
    "date": "25-01-2022",
    "message": "ACTIE VEREIST: xxx",
    "createdAt": "2022-01-25T16:15:34+0100"
}
```

Because contact is `null`, doing something like `$note->contact` results in an exception.
```
Exception: Typed property Xolphin\Responses\Note::$contact must not be accessed before initialization
```

This problem was introduced when switching to typed properties recently: https://github.com/xolphin/xolphin-api-php/commit/ae3df9e3af44caa9d572993fda3bb5531bde94a1



### Fix
The properties that can be null in the API response are now also nullable in the Note class.