### PR TITLE
Fix implicitly nullable arguments to be explicit

### DIFF
--- a/src/Endpoints/RequestsEndpoint.php
+++ b/src/Endpoints/RequestsEndpoint.php
@@ -135,10 +135,10 @@ class RequestsEndpoint
         int $id,
         DateTime $dateTime,
         string $timezone = 'Europe/Amsterdam',
-        string $phoneNumber = null,
-        string $extensionNumber = null,
-        string $email = null,
-        string $comments = null,
+        ?string $phoneNumber = null,
+        ?string $extensionNumber = null,
+        ?string $email = null,
+        ?string $comments = null,
         string $action = 'ScheduledCallback',
         string $language = 'en_us'
     ): Base


### PR DESCRIPTION
There are four arguments in one method where strings are implicitly nullable. This syntax is deprecated in PHP 8.4, so this PR fixes that.

```
Deprecated: Xolphin\Endpoints\RequestsEndpoint::scheduleValidationCall(): Implicitly marking parameter $phoneNumber as nullable is deprecated, the explicit nullable type must be used instead in ./src/Endpoints/RequestsEndpoint.php
```